### PR TITLE
Update config file location / implement set command

### DIFF
--- a/src/Commands/SystemCommands.py
+++ b/src/Commands/SystemCommands.py
@@ -53,7 +53,12 @@ def systemCommands(cmd, uvm):
                     setattr(uvm.currFocusView, 'frame', RedditIndexFrame(uvm))
 
     elif cmd[0] == ('set'):
-        pass
+        # :set key value
+        if len(cmd) == 3:
+            uvm.cfg.set(cmd[1], cmd[2])
+        # :set SITE key value
+        elif len(cmd) == 4:
+            uvm.cfg.deep_set(cmd[1], cmd[2], cmd[3])
 
     elif cmd[0] == ('source'):
         pass

--- a/src/config.py
+++ b/src/config.py
@@ -12,7 +12,7 @@ class Config():
         if location and not os.path.isdir(location):
             self.location = location
         else:
-            self.location = os.path.expanduser('~') + '/.config/commandChan/config.json'
+            self.location = os.path.expanduser('~') + '/.config/TerminusBrowser/config.json'
 
         # load default config
         self.defaults = self._load('./src/default_config.json')

--- a/tests/Commands/test_SystemCommands.py
+++ b/tests/Commands/test_SystemCommands.py
@@ -24,6 +24,21 @@ def test_addChan(test_input, expected, view):
     result = all(ex in view.cfg.deep_get(SITE.FCHAN, 'boards') for ex in expected)
     assert result
 
+test_set = [
+    ('set test ahoy'),
+    ('set REDDIT username test')
+]
+@pytest.mark.parametrize("test_input", test_set)
+def test_setCommand(test_input, view):
+    systemCommands(test_input, view)
+    
+    cmd = test_input.split()
+    if len(cmd) == 3:
+        assert view.cfg.get(cmd[1]) == cmd[2]
+    else:
+        assert view.cfg.deep_get(cmd[1], cmd[2]) == cmd[3]
+
+
 test_subs = [
     ('add reddit linuxgaming', ['linuxgaming']),
     ('add reddit linuxgaming sysadmin', ['linuxgaming', 'sysadmin'])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from config import Config
 
 import pytest
 
-DEFAULT = os.path.expanduser('~') + '/.config/commandChan/config.json'
+DEFAULT = os.path.expanduser('~') + '/.config/TerminusBrowser/config.json'
 test_list = [
     ('', DEFAULT),
     ('/tmp/', DEFAULT),


### PR DESCRIPTION
# Description

I implemented the :set command and switched the config file location to be /TerminusBrowser instead of /commandChan.

For the :set command, it works with either:

`:set KEY VALUE`

or 

`:set SITE KEY VALUE` (ex. `:set REDDIT username test`)

The config currently stores the enum values of the sites as opposed to the "normal" name. What do you guys think about this? Should I open another PR possibly


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] My code is self documenting
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new major crashes/bugs