### PR TITLE
add refresh capability to debug.log (#81)

### DIFF
--- a/TerminusBrowser.py
+++ b/TerminusBrowser.py
@@ -156,6 +156,11 @@ def setup():
 
     main()
 
+def refresh_log():
+    if os.path.exists("debug.log"):
+        os.remove("debug.log")
+
 if __name__ == '__main__' or urwid.web_display.is_web_request():
+    refresh_log()
     setupLogger()
     setup()


### PR DESCRIPTION
# Description

The debug.log file currently retains debug information from previous runs of TerminusBrowser. With this patch, the file is deleted before running the browser again.

Fixes #81 

## Type of change

New feature (non-breaking change which adds functionality)
