### PR TITLE
Modified the Image Prefix.

### DIFF
--- a/src/Frames/fchan/threadFrame.py
+++ b/src/Frames/fchan/threadFrame.py
@@ -12,7 +12,7 @@ class ThreadFrame(AbstractFrame, ChanThreadBuilder):
 
         self.url = 'https://a.4cdn.org' + self.boardString + 'thread/' + str(self.threadNumber) + '.json'
         # self.imageUrl = 'http://boards.4chan.org' + self.boardString + 'thread/' + str(self.threadNumber)
-        self.imgPrefix = 'https://a.4cdn.org/'
+        self.imgPrefix = 'https://i.4cdn.org'
         self.headers = {}
 
         self.postReplyDict = {}


### PR DESCRIPTION
# Description 
Base on the documentation of 4chan.

Image should be prefix with an `i` instead of `a`.

I also remove the last `/` to be the same as the URL in the thread Frame

https://github.com/4chan/4chan-API/blob/master/pages/User_images_and_static_content.md#files-and-images

```
$ grep imgPrefix
src/Frames/builders/chanThreadVisual.py:                self.imgPrefix + self.boardString + str(post["tim"]) + post["ext"] if 'ext' in post else ''
src/Frames/lchan/threadFrame.py:        self.imgPrefix = 'https://www.YEET.com/'
src/Frames/builders/chanThreadBuilder.py:                self.imgPrefix + self.boardString + str(post["tim"]) + post["ext"] if 'ext' in post else ''
src/Frames/fchan/threadFrame.py:        self.imgPrefix = 'https://i.4cdn.org'
```

`self.imgPrefix` is always follow by `self.boardString` and `self.boardString` always start with a `/` in the `default_config.json` 

## Type of change

Small Typo

# Checklist:

- [X] My code follows the style of this project
- [X] I have performed a self-review of my own code
- [X] My code is self documenting
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new major crashes/bugs
- [X] Any new features/functionality have corresponding test cases added
