### PR TITLE
Added Image URL for Lainchan thread.

### DIFF
--- a/src/Frames/builders/chanThreadBuilder.py
+++ b/src/Frames/builders/chanThreadBuilder.py
@@ -25,7 +25,7 @@ class ChanThreadBuilder():
                 str(post['no']),
                 post['com'] if 'com' in post else "",
                 post['now'] if 'now' in post else post['time'],
-                self.imgPrefix + self.boardString + str(post["tim"]) + post["ext"] if 'ext' in post else ''
+                self.imgPrefix + self.boardString + 'src/' + str(post["tim"]) + post["ext"] if 'ext' in post else ''
             )
 
             commentObjList.append(p)

--- a/src/Frames/builders/chanThreadVisual.py
+++ b/src/Frames/builders/chanThreadVisual.py
@@ -25,7 +25,7 @@ class ChanThreadBuilder():
                 str(post['no']),
                 post['com'] if 'com' in post else "",
                 post['now'] if 'now' in post else post['time'],
-                self.imgPrefix + self.boardString + str(post["tim"]) + post["ext"] if 'ext' in post else ''
+                self.imgPrefix + self.boardString + 'src/' + str(post["tim"]) + post["ext"] if 'ext' in post else ''
             )
 
             commentObjList.append(p)

--- a/src/Frames/lchan/threadFrame.py
+++ b/src/Frames/lchan/threadFrame.py
@@ -10,8 +10,8 @@ class ThreadFrame(AbstractFrame, ChanThreadBuilder):
 
         self.threadWidgetDict = {}
 
-        self.url = 'https://www.lainchan.org/' + self.boardString + '/res/' + str(self.threadNumber) + '.json'
-        self.imgPrefix = 'https://www.YEET.com/'
+        self.url = 'https://www.lainchan.org' + self.boardString + '/res/' + str(self.threadNumber) + '.json'
+        self.imgPrefix = 'https://www.lainchan.org'
 
         self.headers = {}
 

--- a/src/default_config.json
+++ b/src/default_config.json
@@ -97,24 +97,24 @@
     },
     "LCHAN": {
         "boards": [
-            "λ",
-            "Δ",
-            "sec",
-            "Ω",
-            "inter",
-            "lit",
-            "music",
-            "vis",
-            "hum",
-            "drug",
-            "zzz",
-            "layer",
-            "q",
-            "r",
-            "culture",
-            "psy",
-            "mega",
-            "random"
+            "/λ/",
+            "/Δ/",
+            "/sec/",
+            "/Ω/",
+            "/inter/",
+            "/lit/",
+            "/music/",
+            "/vis/",
+            "/hum/",
+            "/drug/",
+            "/zzz/",
+            "/layer/",
+            "/q/",
+            "/r/",
+            "/culture/",
+            "/psy/",
+            "/mega/",
+            "/random/"
         ]
     }
 }


### PR DESCRIPTION
- followed the convention API for lainchan
- Rename the Board name for Lainchan.
- Added `src/` to 4chan images.

# Description

Lainchain is a 4chan base API. 

I normalize the Board name in the `default_config` for lainchan to follow the convention name for 4chan board. `/board_name/`.

I also test the `4chan` and `lainchan`  prefixImage with the `src/` and they are working fine. :) 

Did you think it's a good Idea to normalize the board name for `lainchan` in the config file ?

Thanks

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is self documenting
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new major crashes/bugs
- [ ] Any new features/functionality have corresponding test cases added
